### PR TITLE
fix(nix): pin ftui deps to v0.2.0 tag to fix crane vendoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "ftui"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 dependencies = [
  "ftui-core",
  "ftui-layout",
@@ -365,7 +365,7 @@ dependencies = [
 [[package]]
 name = "ftui-backend"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 dependencies = [
  "ftui-core",
  "ftui-render",
@@ -374,7 +374,7 @@ dependencies = [
 [[package]]
 name = "ftui-core"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -390,7 +390,7 @@ dependencies = [
 [[package]]
 name = "ftui-extras"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 dependencies = [
  "ftui-core",
  "ftui-render",
@@ -403,12 +403,12 @@ dependencies = [
 [[package]]
 name = "ftui-i18n"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 
 [[package]]
 name = "ftui-layout"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 dependencies = [
  "ftui-core",
  "rustc-hash",
@@ -418,7 +418,7 @@ dependencies = [
 [[package]]
 name = "ftui-render"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 dependencies = [
  "ahash",
  "bitflags",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "ftui-runtime"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 dependencies = [
  "ftui-backend",
  "ftui-core",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "ftui-style"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -462,7 +462,7 @@ dependencies = [
 [[package]]
 name = "ftui-text"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 dependencies = [
  "ftui-core",
  "ftui-layout",
@@ -474,13 +474,12 @@ dependencies = [
  "smallvec",
  "tracing",
  "unicode-segmentation",
- "unicode-width",
 ]
 
 [[package]]
 name = "ftui-widgets"
 version = "0.2.0"
-source = "git+https://github.com/Dicklesworthstone/frankentui.git?rev=3813bb17282ec561bf9c3f716b8b243c41436261#3813bb17282ec561bf9c3f716b8b243c41436261"
+source = "git+https://github.com/Dicklesworthstone/frankentui.git?tag=v0.2.0#303f6cacd01cf0b9038f1e350af0382209d2bc13"
 dependencies = [
  "ahash",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2024"
 [dependencies]
 arboard = "3.6.1"
 dirs = "6.0.0"
-ftui = { git = "https://github.com/Dicklesworthstone/frankentui.git", rev = "3813bb17282ec561bf9c3f716b8b243c41436261", default-features = false, features = ["runtime", "crossterm"] }
-ftui-extras = { git = "https://github.com/Dicklesworthstone/frankentui.git", rev = "3813bb17282ec561bf9c3f716b8b243c41436261", default-features = false, features = ["text-effects"] }
+ftui = { git = "https://github.com/Dicklesworthstone/frankentui.git", tag = "v0.2.0", default-features = false, features = ["runtime", "crossterm"] }
+ftui-extras = { git = "https://github.com/Dicklesworthstone/frankentui.git", tag = "v0.2.0", default-features = false, features = ["text-effects"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 toml = "0.9.8"


### PR DESCRIPTION
## Summary

- Pin `ftui` and `ftui-extras` git dependencies to the stable `v0.2.0` tag instead of rev `3813bb17`
- The previous rev was force-pushed away from the frankentui repo, causing crane's vendor derivation to produce broken symlinks (only `ftui-fuzz-0.0.0` existed in the git checkout store path)
- Both `cargo check --release` and `nix build` now succeed

Fixes #29

## Test plan

- [x] `cargo check --release` passes
- [x] `cargo test` — all 540 tests pass
- [x] `nix build` completes successfully (all 8 derivations built)
- [x] Pre-commit hooks pass (fmt, clippy, tests)