### PR TITLE
feat(nix): add static config support to home-manager module

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -2,6 +2,13 @@
 
 let
   cfg = config.programs.grove;
+  tomlFormat = pkgs.formats.toml { };
+
+  configAttrs = lib.filterAttrs (_: v: v != null) {
+    inherit (cfg.settings) sidebar-width-pct theme launch-skip-permissions;
+  };
+
+  hasSettings = configAttrs != { };
 in
 {
   options.programs.grove = {
@@ -27,6 +34,26 @@ in
         - GROVE_LAZYGIT_CMD
       '';
     };
+
+    settings = {
+      sidebar-width-pct = lib.mkOption {
+        type = lib.types.nullOr (lib.types.ints.between 10 90);
+        default = null;
+        description = "Sidebar width as a percentage (10-90). Grove default: 33.";
+      };
+
+      theme = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Color theme name. Grove default: catppuccin-mocha.";
+      };
+
+      launch-skip-permissions = lib.mkOption {
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = "Skip permission prompts on workspace launch. Grove default: false.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
@@ -35,6 +62,10 @@ in
     }
     (lib.mkIf (cfg.environment != { }) {
       home.sessionVariables = cfg.environment;
+    })
+    (lib.mkIf hasSettings {
+      xdg.configFile."grove/config.toml".source =
+        tomlFormat.generate "grove-config" configAttrs;
     })
   ]);
 }


### PR DESCRIPTION
## Summary
- Adds `settings` option group to the HM module with `sidebar-width-pct`, `theme`, and `launch-skip-permissions`
- Generates `~/.config/grove/config.toml` declaratively via `pkgs.formats.toml` when any setting is non-null
- Existing `environment` option for env var overrides is unchanged

## Example usage
```nix
programs.grove = {
  enable = true;
  environment.GROVE_CLAUDE_CMD = lib.getExe pkgs.claude-code;
  settings = {
    theme = "monokai";
    sidebar-width-pct = 25;
  };
};
```

## Test plan
- [ ] Verify `home-manager switch` with no settings produces no `config.toml`
- [ ] Verify setting one option generates a valid TOML file with only that key
- [ ] Verify setting all three options generates a complete `config.toml`
- [ ] Verify `environment` option still works alongside `settings`