### PR TITLE
fix(tui): skip tmux sessions without grove metadata during tab restore

### DIFF
--- a/src/ui/tui/mod.rs
+++ b/src/ui/tui/mod.rs
@@ -2092,6 +2092,36 @@ mod tests {
     }
 
     #[test]
+    fn restore_silently_skips_sessions_with_no_grove_metadata() {
+        // Sessions with no @grove_* metadata — both non-grove sessions (e.g.
+        // "nix-config") and stale grove sessions that lost metadata (e.g.
+        // "grove-ws-foo-shell") — should be silently ignored, no warning toast.
+        let rows = format!(
+            "nix-config\t\t\t\t\t\ngrove-ws-stale-project-shell\t\t\t\t\t\n{}-agent-1\t{}\tagent\tCodex 1\tcodex\t9\n",
+            feature_workspace_session(),
+            feature_workspace_path().display(),
+        );
+        let app = GroveApp::from_task_state(
+            "grove".to_string(),
+            crate::ui::state::AppState::new(fixture_tasks(WorkspaceStatus::Idle)),
+            DiscoveryState::Ready,
+            fixture_projects(),
+            AppDependencies {
+                tmux_input: Box::new(RestoreMetadataTmuxInput { rows }),
+                clipboard: test_clipboard(),
+                config_path: unique_config_path("restore-skip-no-metadata"),
+                event_log: Box::new(NullEventLogger),
+                debug_record_start_ts: None,
+            },
+        );
+
+        assert!(
+            app.notifications.visible().is_empty(),
+            "no toast should be shown when sessions without grove metadata are present alongside valid grove sessions"
+        );
+    }
+
+    #[test]
     fn attention_workspace_lookup_supports_numbered_tab_sessions() {
         let mut app = fixture_app();
         select_workspace(&mut app, 1);

--- a/src/ui/tui/update/update_navigation_tabs.rs
+++ b/src/ui/tui/update/update_navigation_tabs.rs
@@ -138,6 +138,11 @@ impl GroveApp {
                 Err(reason) => {
                     if let Some(recovered) = self.recover_legacy_git_tmux_tab_metadata_row(row) {
                         recovered
+                    } else if Self::has_no_grove_metadata(row) {
+                        // Session has no @grove_* variables set at all — either a
+                        // non-grove tmux session or a stale grove session that lost
+                        // its metadata. Silently skip rather than warning the user.
+                        continue;
                     } else {
                         self.log_event_with_fields(
                             "tab_restore",
@@ -573,6 +578,17 @@ impl GroveApp {
             agent_type,
             tab_id,
         })
+    }
+
+    /// Returns true when a tmux list-sessions row has a session name but all
+    /// grove metadata columns (workspace path, kind, title, agent, id) are
+    /// empty. This covers both non-grove tmux sessions and stale grove
+    /// sessions that lost their metadata variables.
+    fn has_no_grove_metadata(row: &str) -> bool {
+        let segments: Vec<&str> = row.split('\t').collect();
+        segments.len() == 6
+            && trimmed_nonempty(segments[0]).is_some()
+            && segments[1..].iter().all(|s| s.trim().is_empty())
     }
 
     fn recover_legacy_git_tmux_tab_metadata_row(


### PR DESCRIPTION
## Summary

- Tmux sessions without `@grove_*` metadata variables (both non-grove sessions like `nix-config` and stale grove sessions that lost their metadata) were being counted as "invalid metadata" errors during tab restore, producing a spurious warning toast on every startup.
- Added `has_no_grove_metadata()` check that silently skips these sessions after legacy git session recovery fails, so they don't trigger warnings while still allowing legitimate legacy sessions to be recovered.

## Context

When a user has regular (non-grove) tmux sessions running (e.g. `nix-config`, `web-monorepo`, `222`), or stale grove sessions that lost their `@grove_*` variables, Grove's startup tab restore would flag every one of these as "invalid metadata" and show a warning toast like:

> 6 tmux sessions skipped during restore (6 invalid metadata)

This happened because `tmux list-sessions` returns all sessions, and sessions without grove metadata have empty fields that fail parsing.

## Test plan

- [x] Added `restore_silently_skips_sessions_with_no_grove_metadata` test covering both non-grove sessions and stale grove sessions
- [x] Existing `restore_recovers_legacy_git_session_without_metadata` test still passes (legacy git recovery preserved)
- [x] All 13 restore-related tests pass
- [x] `make precommit` passes (fmt, check, clippy)
- [x] Full `cargo test` passes (781 tests)